### PR TITLE
Deploy crossPool, A and B simple tokens

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -1,0 +1,29 @@
+######################################################
+##
+## The [.env.local] file is regenerated each time you run deployContracts.sh
+## !!! You don't have to make any changes in it.
+##
+## Below is just a sample how it may look
+##
+######################################################
+
+## [./.env.local]
+
+## TestToken and Weth deployed:
+TEST_TOKEN_ADDRESS=
+WETH_ADDRESS=
+## Uniswap contracts deployed:
+UNISWAP_FACTORY_ADDRESS=
+UNISWAP_ROUTER_ADDRESS=
+UNISWAP_QUOTER_ADDRESS=
+UNISWAP_NFT_DESCRIPTOR_LIBRARY_ADDRESS=
+UNISWAP_POSITION_DESCRIPTOR_ADDRESS=
+UNISWAP_POSITION_MANAGER_ADDRESS=
+
+## SimpleToken deployed to:
+## SimpleTokenFactory deployed:
+SIMPLE_TOKEN_FACTORY_ADDRESS=
+TOKEN_A_ADDRESS=
+TOKEN_B_ADDRESS=
+## A-B Cross Pool deployed:
+A_B_POOL_ADDRESS=

--- a/deployContracts.sh
+++ b/deployContracts.sh
@@ -1,32 +1,71 @@
 #!/usr/bin/env bash
 
-SCRIPT_DIR_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+#SCRIPT_DIR_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 env_file=./.env.local
 network=${1:-localhost}
 sleep_time=1
+execute_all=false
+
+print_help() {
+  echo -e "\nUsage:"
+  echo -e "  deployContracts.sh --all\n    - this will deploy everything including pools WET-TEST and pool A-B\n"
+  echo -e "  deployContracts.sh --network {hardhat network name}\n    - this will exec deploys on predefined Hardhat network from hardhat.config.ts\n"
+}
+
+for arg in "$@"
+do
+    case $arg in
+        --all)
+            execute_all=true
+            shift
+            ;;
+        --network)
+            network="$2"
+            shift 2
+            ;;
+        --help)
+            print_help
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $arg"
+            echo ""
+            print_help
+            exit 1
+            ;;
+    esac
+done
 
 echo Removing ${env_file}
 rm "${env_file}"
 
 echo -e "Deploy on network [${network}]\n"
 
+echo -e "## [${env_file}]\n" > "${env_file}"
+
 echo -n "Deploying Tokens..."
-npx hardhat run scripts/deployTokens.ts --network ${network} > "${env_file}"
+
+npx hardhat run scripts/deployTokens.ts --network ${network} >> "${env_file}"
 echo -e "Done.\nWait ${sleep_time} sec." && sleep $sleep_time
 
-. "${env_file}"
 echo -n "Deploying Uniswap contracts..."
 npx hardhat run scripts/deployUniswap.ts --network ${network} >> "${env_file}"
-echo -e "Done.\nWait ${sleep_time} sec." && sleep $sleep_time
-
-. "${env_file}"
-echo -n "Deploying Uniswap Pool..."
-npx hardhat run scripts/deployPool.ts --network ${network} >> "${env_file}"
-echo -e "Done.\nWait ${sleep_time} sec." && sleep $sleep_time
+echo -e "Done.\nWait 5 sec." && sleep 5
 
 echo -n "Deploying SimpleTokenFactory..."
 npx hardhat run scripts/deploySimple.ts --network ${network} >> "${env_file}"
-echo -e "Done.\nWait ${sleep_time} sec." && sleep $sleep_time
+echo -e "Done.\nWait 5 sec." && sleep 5
+
+if $execute_all; then
+  echo -n "Deploying Uniswap CrossPool A-B..."
+  npx hardhat run scripts/deployCrossPool.ts --network ${network} >> "${env_file}"
+  echo -e "Done.\nWait ${sleep_time} sec." && sleep $sleep_time
+
+  echo -n "Deploying Uniswap Pool..."
+  npx hardhat run scripts/deployPool.ts --network ${network} >> "${env_file}"
+  echo -e "Done.\nWait ${sleep_time} sec." && sleep $sleep_time
+fi
 
 echo -e "\n[${env_file}]:"
 cat ${env_file}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -7,6 +7,8 @@ import '@nomiclabs/hardhat-etherscan';
 import dotenv from 'dotenv';
 import { RemoteContract } from 'hardhat-gas-reporter/dist/src/types';
 dotenv.config();
+dotenv.config({ path: '.env.local' });
+
 type ContractJson = { abi: any; bytecode: string };
 const UniswapContractArtifacts: { [name: string]: ContractJson } = {
   Quoter: require('@uniswap/v3-periphery/artifacts/contracts/lens/Quoter.sol/Quoter.json'),
@@ -29,6 +31,7 @@ const getRemoteContract = (contractName: string, envName: string) => {
         }
       ];
 };
+
 const remoteContracts: RemoteContract[] = [
   ...getRemoteContract('UniswapV3Factory', 'UNISWAP_FACTORY_ADDRESS'),
   ...getRemoteContract('SwapRouter', 'UNISWAP_ROUTER_ADDRESS'),

--- a/scripts/deployCrossPool.ts
+++ b/scripts/deployCrossPool.ts
@@ -2,14 +2,14 @@ import { ethers } from 'hardhat';
 import { UniswapContractArtifacts } from '../utils/UniswapV3Deployer';
 import { encodePriceSqrt } from '../utils/encodePriceSqrt';
 
-const WETH_ADDRESS = String(process.env.WETH_ADDRESS);
-const TEST_TOKEN_ADDRESS = String(process.env.TEST_TOKEN_ADDRESS);
+const TOKEN_A_ADDRESS = String(process.env.TOKEN_A_ADDRESS);
+const TOKEN_B_ADDRESS = String(process.env.TOKEN_B_ADDRESS);
 const UNISWAP_FACTORY_ADDRESS = String(process.env.UNISWAP_FACTORY_ADDRESS);
 const UNISWAP_POSITION_MANAGER_ADDRESS = String(process.env.UNISWAP_POSITION_MANAGER_ADDRESS);
 
 const poolConfig = {
-  token0: WETH_ADDRESS,
-  token1: TEST_TOKEN_ADDRESS,
+  token0: TOKEN_A_ADDRESS,
+  token1: TOKEN_B_ADDRESS,
   fee: 500
 };
 
@@ -46,8 +46,8 @@ async function main() {
     poolAddress = existingPoolAddress;
   }
 
-  console.log('## WETH/TEST_TOKEN Pool deployed:');
-  console.log(`WETH_TEST_TOKEN_POOL_ADDRESS=${poolAddress}`);
+  console.log('## Cross Pool A-B deployed:');
+  console.log(`POOL_A_B_ADDRESS=${poolAddress}`);
 }
 
 main()

--- a/scripts/deploySimple.ts
+++ b/scripts/deploySimple.ts
@@ -1,18 +1,48 @@
 import { ethers } from 'hardhat';
-import { ContractFactory } from 'ethers';
+import { BigNumber, ContractFactory } from 'ethers';
 import { SimpleToken, SimpleFactory } from '../typechain-types';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+
+async function createToken(
+  simpleFactory: SimpleFactory,
+  initialSupply: BigNumber,
+  deployer: SignerWithAddress,
+  params: Record<string, string>
+) {
+  // Deploy Simple tokens with SimpleFactory
+  const tx = await simpleFactory.createToken(
+    params.name,
+    params.symbol || params.name.toUpperCase() + 'SIMPL',
+    initialSupply,
+    deployer.address
+  );
+  await tx.wait();
+  const receipt = await tx.wait();
+
+  const tokenCreatedEvent = receipt.events?.find(
+    (event) => event.event === 'tokenCreated' && event.args?.length && event.args[1].toString() === deployer.address
+  );
+
+  if (!tokenCreatedEvent) {
+    console.log('## Token creation event not found. Address cannot be fetched');
+    throw new Error();
+  }
+
+  const [tokenAddress] = tokenCreatedEvent.args || [];
+  return tokenAddress;
+}
 
 async function main() {
   const [deployer] = await ethers.getSigners();
+  const initialSupply = ethers.utils.parseUnits('1000000000', 18);
 
   // Deploy SimpleToken contract
-  const SimpleTokenFactory: ContractFactory = await ethers.getContractFactory('SimpleToken');
-  const initialSupply = ethers.utils.parseUnits('1000000000', 18);
-  const simpleToken: SimpleToken = <SimpleToken>(
-    await SimpleTokenFactory.deploy('MyToken', 'MTK', initialSupply, deployer.address)
-  );
-  await simpleToken.deployed();
-  console.log('## SimpleToken deployed to:', simpleToken.address);
+  // const SimpleTokenFactory: ContractFactory = await ethers.getContractFactory('SimpleToken');
+  // const simpleToken: SimpleToken = <SimpleToken>(
+  //   await SimpleTokenFactory.deploy('MyToken', 'MTK', initialSupply, deployer.address)
+  // );
+  // await simpleToken.deployed();
+  // console.log('## SimpleToken deployed to:', simpleToken.address);
 
   // Deploy SimpleFactory contract
   const SimpleFactoryFactory: ContractFactory = await ethers.getContractFactory('SimpleFactory');
@@ -20,6 +50,16 @@ async function main() {
   await simpleFactory.deployed();
   console.log('## SimpleTokenFactory deployed:');
   console.log(`SIMPLE_TOKEN_FACTORY_ADDRESS=${simpleFactory.address}`);
+
+  const addressTokenA = await createToken(simpleFactory, initialSupply, deployer, {
+    name: 'A'
+  });
+  console.log(`TOKEN_A_ADDRESS=${addressTokenA}`);
+
+  const addressTokenB = await createToken(simpleFactory, initialSupply, deployer, {
+    name: 'B'
+  });
+  console.log(`TOKEN_B_ADDRESS=${addressTokenB}`);
 }
 
 main()

--- a/scripts/deployTokens.ts
+++ b/scripts/deployTokens.ts
@@ -4,22 +4,20 @@ import { TokenFactoryDeployer } from '../utils/TokenFactoryDeployer';
 async function main() {
   const [deployer] = await ethers.getSigners();
 
-  const [TestToken, Weth] = await Promise.all([
-    TokenFactoryDeployer.deploy(deployer, {
-      name: 'TEST_ABSTRACT_TOKEN',
-      symbol: 'TAT',
-      supply: '1000000000'
-    }),
-    TokenFactoryDeployer.deploy(deployer, {
-      name: 'Wrapped Ether',
-      symbol: 'WETH',
-      supply: '1000000000'
-    })
-  ]);
+  const Weth = await TokenFactoryDeployer.deploy(deployer, {
+    name: 'Wrapped Ether',
+    symbol: 'WETH',
+    supply: '1000000000'
+  });
+  const TestToken = await TokenFactoryDeployer.deploy(deployer, {
+    name: 'TEST_ABSTRACT_TOKEN',
+    symbol: 'TAT',
+    supply: '1000000000'
+  });
 
   console.log('## TestToken and Weth deployed:');
-  console.log(`TEST_TOKEN_ADDRESS=${TestToken.address}`);
   console.log(`WETH_ADDRESS=${Weth.address}`);
+  console.log(`TEST_TOKEN_ADDRESS=${TestToken.address}`);
 
   return {
     TestToken,

--- a/test/Uniswap.ts
+++ b/test/Uniswap.ts
@@ -188,6 +188,7 @@ describe.only('Uniswap', () => {
     expect(token1).to.equal(TestToken.address);
   });
 
+  // it('Creates position', async () => {
   it.skip('Creates position', async () => {
     console.log('###### it(Creates position) ######\n');
     const [deployer] = await ethers.getSigners();
@@ -323,16 +324,23 @@ describe.only('Uniswap', () => {
 
     console.log('## Executing exactInputSingle with params:');
     console.log('# ', printSwapParams(swapParams));
-
-    console.info('# Pool before tx:', await printPool(pool));
+    const printedPoolBefore = await printPool(pool);
+    const poolPriceBefore = printedPoolBefore.sqrtPriceX96;
+    console.log('## BEFORE: pool.price =', poolPriceBefore);
+    console.info('\n# Pool before tx:', printedPoolBefore);
     console.log('--- pool.liquidity before Swap:', toETH(await pool.liquidity()));
-    console.log(`# expecting TestToken balance of wallet[${deployer.address}] changed by:`, quotedAmountOut);
+    console.log('\n$$ executing swap $$\n');
+    // console.log(`# expecting TestToken balance of wallet[${deployer.address}] changed by:`, toETH(quotedAmountOut));
     await expect(
       UniswapContracts.router.connect(deployer).exactInputSingle(swapParams, {
         gasLimit: ethers.utils.hexlify(5000000)
       })
     ).to.changeTokenBalance(TestToken, deployer.address, `${quotedAmountOut}`);
-    console.info('# Pool before tx:', await printPool(pool));
+    const printedPoolAfter = await printPool(pool);
+    const poolPriceAfter = printedPoolAfter.sqrtPriceX96;
+    console.log('## AFTER: pool.price =', poolPriceAfter);
+    console.log('## price diff: before-after=', poolPriceBefore - poolPriceAfter);
+    console.info('\n# Pool after tx:', printedPoolAfter);
     console.log('--- pool.liquidity after swap:', toETH(await pool.liquidity()));
     await printPositions(UniswapContracts.positionManager, deployer.address);
     console.log('###### it(Process ExactInputSingle Swap) END ######\n');

--- a/utils/poolHelpers.ts
+++ b/utils/poolHelpers.ts
@@ -38,10 +38,9 @@ export const printPool = async (pool: Contract) => {
     token1: printToken(immutables.token1),
     fee: immutables.fee,
     tickSpacing: state.tickSpacing,
-    liquidity: state.liquidity,
-    sqrtPriceX96: state.sqrtPriceX96,
-    tick: state.tick,
-    slot0: await pool.slot0()
+    liquidity: toETH(state.liquidity),
+    sqrtPriceX96: Math.sqrt(state.sqrtPriceX96 / 2 ** 96),
+    tick: state.tick
   };
 };
 
@@ -61,7 +60,7 @@ export const printUniswapV3Pool = (pool: Pool) => {
   };
 };
 
-export const toETH = (wei: string) => ethers.utils.commify(ethers.utils.formatEther(wei)) + 'ETH';
+export const toETH = (wei: string) => ethers.utils.commify(ethers.utils.formatEther(wei));
 
 export async function getPositionIds(positionContract: Contract, ownerAddress: string): Promise<number[]> {
   if (!ownerAddress) {
@@ -117,7 +116,7 @@ export const printSwapParams = (swapParams: any) => ({
   deadline: swapParams.deadline,
   amountIn: toETH(swapParams.amountIn),
   amountOutMinimum: toETH(swapParams.amountOutMinimum),
-  sqrtPriceLimitX96: swapParams.sqrtPriceLimitX96
+  sqrtPriceLimitX96: toETH(swapParams.sqrtPriceLimitX96)
 });
 
 export const printPositions = async (positionManagerContract: Contract, ownerAddress: string) => {


### PR DESCRIPTION
- added  A & B simple tokens deploy 
> TOKEN_A_ADDRESS ==> .env.local
> TOKEN_B_ADDRESS ==> .env.local


- added crossPool deploy for theese tokens
 _(with_ **--all** _arg enabled, see below)_
> POOL_A_B_ADDRESS ==> .env.local


-  deployContracts.sh is **not** deploying pools by default now
It deploys tokens and Uniswap factories 
 (see usage: `deployContracts.sh --help`)
> Usage:
  deployContracts.sh --all
    - this will deploy everythin including pools WET-TEST and pool A-B
>
>  deployContracts.sh --network {hardhat network name}
    - this will exec deploys on predefined Hardhat network from hardhat.config.ts

- hardhat.config fixed so it correctly reads .env.local file

